### PR TITLE
Add wait-for-deployments feature

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,5 @@
 FROM python:3.7-alpine
 
-LABEL version="1.0.1" \
-  repository="https://github.com/niteoweb/reviewapps-deploy-status" \
-  homepage="https://github.com/niteoweb" \
-  maintainer="niteo.co" \
-  "com.github.actions.name"="Heroku Review App Deployment Status" \
-  "com.github.actions.description"="A Github Action to test the deployment status of a Heroku Review App." \
-  "com.github.actions.icon"="git-pull-request" \
-  "com.github.actions.color"="orange"
-
 RUN pip install --upgrade pip
 RUN pip install requests==2.22.0
 

--- a/README.md
+++ b/README.md
@@ -22,12 +22,13 @@ A Github Action that tests the deployment status of a Heroku Review App.
         
         steps:
         - name: Run review-app test
-          uses: niteoweb/reviewapps-deploy-status@v1.0.1
+          uses: niteoweb/reviewapps-deploy-status@v1.0.2
           env:
               GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           with:
               interval: 10 # in seconds, optional, default is 10
               accepted_responses: 200 # comma separated status codes, optional, default is 200
+              deployments_timeout: 120 # in seconds, optional, default is 120
     ```
 
 > Note: Work flow should include `pull_request` event.
@@ -40,6 +41,7 @@ A Github Action that tests the deployment status of a Heroku Review App.
     |---|---|---|
     | interval | Wait for this amount of seconds before retrying the build check  | 10  |
     | accepted_responses | Allow/Accept the specified status codes | 200  |
+    | deployments_timeout | Maximum waiting time (in seconds) to fetch the deployments | 120 |
 
 ## Local Development
 * Create a Python virtual environment(version > 3.6).

--- a/action.yml
+++ b/action.yml
@@ -20,3 +20,7 @@ inputs:
     description: Status(es) which can be accepted. Separated by comma.
     required: false
     default: 200 # All OK status
+  deployments_timeout:
+    description: Maximum waiting time to fetch the deployments.
+    required: false
+    default: 120 # 120 seconds


### PR DESCRIPTION
* Now the action will retry until the `deployments_timeout` secs (default is 300 sec) to fetch deployments.
* All the labels are now available from action.yml. Hence these can be removed from docker.yml

Ref: https://github.com/niteoweb/operations/issues/1091