### PR TITLE
Make Review App URL available for other steps in workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ A Github Action that tests the deployment status of a Heroku Review App.
         
         steps:
         - name: Run review-app test
-          uses: niteoweb/reviewapps-deploy-status@v1.2.0
+          id: review_app_test  # `id` value is used to refer the outputs from the corresponding action 
+          uses: niteoweb/reviewapps-deploy-status@v1.3.0
           env:
               GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           with:
@@ -46,6 +47,11 @@ A Github Action that tests the deployment status of a Heroku Review App.
 
             # Max time to be spent retrying for the response check, default is 120
             publish_timeout: 120
+
+        # `steps.review_app_test.outputs.review_app_url` must be used in workflow to fetch the Review App URL 
+        - name: Check review_app_url
+          run: |
+            echo "Outputs - ${{ steps.review_app_test.outputs.review_app_url }}"
     ```
 
 > Note: Work flow should include `pull_request` event.

--- a/action.yml
+++ b/action.yml
@@ -41,3 +41,7 @@ inputs:
     description: Maximum time to spend retrying the HTTP response check until it succeeds.
     required: false
     default: 120
+
+outputs:
+  review_app_url:
+    description: "Review App URL from the action."

--- a/review_app_status.py
+++ b/review_app_status.py
@@ -225,6 +225,7 @@ def main() -> None:
             interval=args.interval,
         )
 
+    print(f"::set-output name=review_app_url::{review_app_url}")
     print("Successful")
 
 

--- a/tests.py
+++ b/tests.py
@@ -307,6 +307,8 @@ def test_main_success(
     )
 
     out, err = capsys.readouterr()
+
+    "set-output name=review_app_url::https://foo-pr-bar.herokuapp.com" in out
     "Successful" in out
 
 


### PR DESCRIPTION
* Review App URL can be accessed using `steps.review_app_test.outputs.review_app_url` in other steps.

closes: https://github.com/niteoweb/reviewapps-deploy-status/issues/5