### PR TITLE
Add the Heroku app name to output.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ A Github Action that tests the deployment status of a Heroku Review App.
         # `steps.review_app_test.outputs.review_app_url` must be used in workflow to fetch the Review App URL 
         - name: Check review_app_url
           run: |
-            echo "Outputs - ${{ steps.review_app_test.outputs.review_app_url }}"
+            echo "Outputs :"
+            echo "- App name: ${{ steps.review_app_test.outputs.review_app_name }}"
+            echo "- App url: ${{ steps.review_app_test.outputs.review_app_url }}"
     ```
 
 > Note: Work flow should include `pull_request` event.

--- a/action.yml
+++ b/action.yml
@@ -43,5 +43,7 @@ inputs:
     default: 120
 
 outputs:
+  review_app_name:
+    description: "The name of the Heroku review app deployed."
   review_app_url:
-    description: "Review App URL from the action."
+    description: "The URL of the Heroku review app deployed."

--- a/review_app_status.py
+++ b/review_app_status.py
@@ -216,8 +216,10 @@ def main() -> None:
         logger.info(f"Load time delay: {args.load_time_delay} seconds")
         time.sleep(args.load_time_delay)
 
+        review_app_name = reviewapp_build_data['environment']
+        review_app_url = f"https://{review_app_name}.herokuapp.com"
+
         # Check the HTTP response from app URL
-        review_app_url = f"https://{reviewapp_build_data['environment']}.herokuapp.com"
         _check_review_app_deployment_status(
             review_app_url=review_app_url,
             accepted_responses=args.accepted_responses,
@@ -225,6 +227,7 @@ def main() -> None:
             interval=args.interval,
         )
 
+    print(f"::set-output name=review_app_name::{review_app_name}")
     print(f"::set-output name=review_app_url::{review_app_url}")
     print("Successful")
 

--- a/tests.py
+++ b/tests.py
@@ -309,6 +309,7 @@ def test_main_success(
     out, err = capsys.readouterr()
 
     "set-output name=review_app_url::https://foo-pr-bar.herokuapp.com" in out
+    "set-output name=review_app_name::foo-pr-bar" in out
     "Successful" in out
 
 


### PR DESCRIPTION
Hi, 
As said in #9, you get the Heroku app name in the action and _convert_ it the the url. 

This PR adds the app name to the output, so developers can directly get it in their actions without extracting it from the url.

Thanks.